### PR TITLE
Add placeholder filesystem drivers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,30 @@ LDFLAGS = -m elf_i386
 BUILD = build
 ISO = OptrixOS.iso
 
+OBJS = $(BUILD)/boot.o $(BUILD)/kernel.o \
+       $(BUILD)/vfs.o $(BUILD)/ext2.o $(BUILD)/fat32.o $(BUILD)/ntfs.o
+
 all: $(BUILD)/kernel.bin
 
-$(BUILD)/kernel.bin: $(BUILD)/boot.o $(BUILD)/kernel.o linker.ld
-	$(LD) $(LDFLAGS) -T linker.ld -o $@ $(BUILD)/boot.o $(BUILD)/kernel.o
+$(BUILD)/kernel.bin: $(OBJS) linker.ld
+	$(LD) $(LDFLAGS) -T linker.ld -o $@ $(OBJS)
 
 $(BUILD)/boot.o: src/boot.s | $(BUILD)
 	$(NASM) -f elf32 $< -o $@
 
 $(BUILD)/kernel.o: src/kernel.c | $(BUILD)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD)/vfs.o: src/fs/vfs.c | $(BUILD)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD)/ext2.o: src/fs/ext2.c | $(BUILD)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD)/fat32.o: src/fs/fat32.c | $(BUILD)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD)/ntfs.o: src/fs/ntfs.c | $(BUILD)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 $(BUILD):

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # OptrixOS-Codex
 
-This repository contains a very small example OS that boots via GRUB and prints a message to the screen. It provides a starting point for experimenting with OS development.
+This repository contains a very small example OS that boots via GRUB and prints a message to the screen. It provides a starting point for experimenting with OS development. A skeleton VFS layer and placeholder drivers for ext2, FAT32 and NTFS are included for future expansion.
 
 ## Building
 
 1. Install `nasm`, `grub-pc-bin` and `xorriso`.
 2. Run `python3 compile_tools.py` or simply `make iso` to build `OptrixOS.iso`.
+   The build requires `grub-mkrescue`. If GRUB is missing you can still build
+   `kernel.bin` using `make`, but creating a bootable ISO will fail.
 3. Test the ISO with an emulator such as QEMU:
    ```bash
    qemu-system-i386 -cdrom OptrixOS.iso

--- a/compile_tools.py
+++ b/compile_tools.py
@@ -34,7 +34,13 @@ def compile_kernel():
     os.makedirs('build', exist_ok=True)
     run([NASM, '-f', 'elf32', 'src/boot.s', '-o', 'build/boot.o'])
     run([CC, '-m32', '-ffreestanding', '-O2', '-c', 'src/kernel.c', '-o', 'build/kernel.o'])
-    run([LD, '-m', 'elf_i386', '-T', 'linker.ld', '-o', 'build/kernel.bin', 'build/boot.o', 'build/kernel.o'])
+    run([CC, '-m32', '-ffreestanding', '-O2', '-c', 'src/fs/vfs.c', '-o', 'build/vfs.o'])
+    run([CC, '-m32', '-ffreestanding', '-O2', '-c', 'src/fs/ext2.c', '-o', 'build/ext2.o'])
+    run([CC, '-m32', '-ffreestanding', '-O2', '-c', 'src/fs/fat32.c', '-o', 'build/fat32.o'])
+    run([CC, '-m32', '-ffreestanding', '-O2', '-c', 'src/fs/ntfs.c', '-o', 'build/ntfs.o'])
+    run([LD, '-m', 'elf_i386', '-T', 'linker.ld', '-o', 'build/kernel.bin',
+         'build/boot.o', 'build/kernel.o', 'build/vfs.o', 'build/ext2.o',
+         'build/fat32.o', 'build/ntfs.o'])
 
 def make_iso():
     os.makedirs('build/isofiles/boot/grub', exist_ok=True)

--- a/src/fs/ext2.c
+++ b/src/fs/ext2.c
@@ -1,0 +1,18 @@
+#include "ext2.h"
+#include <stddef.h>
+
+void ext2_init(void) {
+    /* TODO: initialize ext2 driver */
+}
+
+int ext2_read(const char *path, void *buf, unsigned long len) {
+    (void)path; (void)buf; (void)len;
+    /* TODO: read from ext2 */
+    return -1;
+}
+
+int ext2_write(const char *path, const void *buf, unsigned long len) {
+    (void)path; (void)buf; (void)len;
+    /* TODO: write to ext2 */
+    return -1;
+}

--- a/src/fs/ext2.h
+++ b/src/fs/ext2.h
@@ -1,0 +1,8 @@
+#ifndef EXT2_H
+#define EXT2_H
+
+void ext2_init(void);
+int ext2_read(const char *path, void *buf, unsigned long len);
+int ext2_write(const char *path, const void *buf, unsigned long len);
+
+#endif // EXT2_H

--- a/src/fs/fat32.c
+++ b/src/fs/fat32.c
@@ -1,0 +1,18 @@
+#include "fat32.h"
+#include <stddef.h>
+
+void fat32_init(void) {
+    /* TODO: initialize FAT32 driver */
+}
+
+int fat32_read(const char *path, void *buf, unsigned long len) {
+    (void)path; (void)buf; (void)len;
+    /* TODO: read from FAT32 */
+    return -1;
+}
+
+int fat32_write(const char *path, const void *buf, unsigned long len) {
+    (void)path; (void)buf; (void)len;
+    /* TODO: write to FAT32 */
+    return -1;
+}

--- a/src/fs/fat32.h
+++ b/src/fs/fat32.h
@@ -1,0 +1,8 @@
+#ifndef FAT32_H
+#define FAT32_H
+
+void fat32_init(void);
+int fat32_read(const char *path, void *buf, unsigned long len);
+int fat32_write(const char *path, const void *buf, unsigned long len);
+
+#endif // FAT32_H

--- a/src/fs/ntfs.c
+++ b/src/fs/ntfs.c
@@ -1,0 +1,18 @@
+#include "ntfs.h"
+#include <stddef.h>
+
+void ntfs_init(void) {
+    /* TODO: initialize NTFS driver */
+}
+
+int ntfs_read(const char *path, void *buf, unsigned long len) {
+    (void)path; (void)buf; (void)len;
+    /* TODO: read from NTFS */
+    return -1;
+}
+
+int ntfs_write(const char *path, const void *buf, unsigned long len) {
+    (void)path; (void)buf; (void)len;
+    /* TODO: write to NTFS */
+    return -1;
+}

--- a/src/fs/ntfs.h
+++ b/src/fs/ntfs.h
@@ -1,0 +1,8 @@
+#ifndef NTFS_H
+#define NTFS_H
+
+void ntfs_init(void);
+int ntfs_read(const char *path, void *buf, unsigned long len);
+int ntfs_write(const char *path, const void *buf, unsigned long len);
+
+#endif // NTFS_H

--- a/src/fs/vfs.c
+++ b/src/fs/vfs.c
@@ -1,0 +1,24 @@
+#include "vfs.h"
+#include <stddef.h>
+
+void vfs_init(void) {
+    /* Initialize VFS structures. */
+}
+
+int vfs_mount(fs_type_t type) {
+    (void)type; /* unused */
+    /* TODO: mount appropriate file system driver */
+    return 0;
+}
+
+int vfs_read(const char *path, void *buf, unsigned long len) {
+    (void)path; (void)buf; (void)len;
+    /* TODO: dispatch read to proper FS driver */
+    return -1;
+}
+
+int vfs_write(const char *path, const void *buf, unsigned long len) {
+    (void)path; (void)buf; (void)len;
+    /* TODO: dispatch write to proper FS driver */
+    return -1;
+}

--- a/src/fs/vfs.h
+++ b/src/fs/vfs.h
@@ -1,0 +1,15 @@
+#ifndef VFS_H
+#define VFS_H
+
+typedef enum {
+    FS_EXT2,
+    FS_FAT32,
+    FS_NTFS
+} fs_type_t;
+
+void vfs_init(void);
+int vfs_mount(fs_type_t type);
+int vfs_read(const char *path, void *buf, unsigned long len);
+int vfs_write(const char *path, const void *buf, unsigned long len);
+
+#endif // VFS_H

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -1,4 +1,5 @@
 #include <stddef.h>
+#include "fs/vfs.h"
 
 static volatile unsigned char *video = (unsigned char *)0xb8000;
 
@@ -8,6 +9,9 @@ void kernel_main(void) {
         video[i * 2] = msg[i];
         video[i * 2 + 1] = 0x07;
     }
+    vfs_init();
+    vfs_mount(FS_EXT2);
+
     for (;;) {
         __asm__("hlt");
     }


### PR DESCRIPTION
## Summary
- sketch out a simple VFS layer
- add placeholder drivers for ext2, FAT32 and NTFS
- update `kernel.c` to init/mount the VFS
- expand Makefile and build script to compile new modules
- document GRUB requirement and filesystem stubs in README

## Testing
- `make`
- `make iso` *(fails: grub-mkrescue not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855e518c300832fbcfd19d9f6c0d37f