### PR TITLE
Add custom bootloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+OptrixOS.img

--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 # OptrixOS-Codex
 
-This repository contains a very small example OS that boots via GRUB and prints a message to the screen. It provides a starting point for experimenting with OS development. A basic VFS layer with minimal ext2, FAT32 and NTFS drivers is included for demonstration purposes.
+This repository contains a very small example OS that now boots using a custom bootloader and prints a message to the screen. It provides a starting point for experimenting with OS development. A basic VFS layer with minimal ext2, FAT32 and NTFS drivers is included for demonstration purposes.
 
 ## Building
 
-1. Install `nasm`, `grub-pc-bin` and `xorriso`.
-2. Run `python3 compile_tools.py` or simply `make iso` to build `OptrixOS.iso`.
-   ISO creation now uses `grub-mkstandalone` together with `xorriso`.
-3. Test the ISO with an emulator such as QEMU:
+1. Install `nasm`.
+2. Run `python3 compile_tools.py` or simply `make` to build `OptrixOS.img`.
+3. Test the image with an emulator such as QEMU:
    ```bash
-   qemu-system-i386 -cdrom OptrixOS.iso
+   qemu-system-i386 -drive format=raw,file=OptrixOS.img
    ```
 
-The `compile_tools.py` script sets up toolchain defaults and builds the kernel and ISO using `grub-mkstandalone` and `xorriso`.
+The `compile_tools.py` script sets up toolchain defaults and builds the kernel and bootable image without relying on GRUB.

--- a/src/boot.s
+++ b/src/boot.s
@@ -1,9 +1,4 @@
 BITS 32
-section .multiboot
-    dd 0x1BADB002
-    dd 0
-    dd -(0x1BADB002 + 0)
-
 section .text
 extern kernel_main
     global _start

--- a/src/bootloader.s
+++ b/src/bootloader.s
@@ -1,0 +1,106 @@
+[bits 16]
+[org 0x7C00]
+
+%ifndef KERNEL_SECTORS
+%define KERNEL_SECTORS 1
+%endif
+
+%ifndef KERNEL_LBA
+%define KERNEL_LBA 1
+%endif
+
+%ifndef KERNEL_LOAD_ADDR
+%define KERNEL_LOAD_ADDR 0x00100000
+%endif
+
+start:
+    xor ax, ax
+    mov ds, ax
+    mov es, ax
+    mov ss, ax
+    mov sp, 0x7C00
+
+    mov [BOOT_DRIVE], dl
+
+    ; set up disk address packet
+    mov word [dap+2], KERNEL_SECTORS
+    mov dword [dap+4], KERNEL_LOAD_ADDR
+    mov dword [dap+8], KERNEL_LBA
+    mov dword [dap+12], 0
+
+    mov si, dap
+    mov dl, [BOOT_DRIVE]
+    mov ah, 0x42
+    int 0x13
+    jc disk_error
+
+    call enable_a20
+
+    cli
+    lgdt [gdt_desc]
+    mov eax, cr0
+    or eax, 1
+    mov cr0, eax
+    jmp CODE_SEL:protected
+
+[bits 32]
+protected:
+    mov ax, DATA_SEL
+    mov ds, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+    mov ss, ax
+    mov esp, 0x90000
+    mov eax, KERNEL_LOAD_ADDR
+    jmp eax
+
+[bits 16]
+disk_error:
+    cli
+    hlt
+    jmp disk_error
+
+enable_a20:
+    in al, 0x92
+    or al, 2
+    out 0x92, al
+    ret
+
+; GDT with null, code, data
+ALIGN 4
+gdt_start:
+    dq 0
+gdt_code:
+    dw 0xFFFF
+    dw 0
+    db 0
+    db 0x9A
+    db 0xCF
+    db 0
+gdt_data:
+    dw 0xFFFF
+    dw 0
+    db 0
+    db 0x92
+    db 0xCF
+    db 0
+gdt_end:
+
+gdt_desc:
+    dw gdt_end - gdt_start - 1
+    dd gdt_start
+
+CODE_SEL equ 0x08
+DATA_SEL equ 0x10
+
+BOOT_DRIVE db 0
+
+dap:
+    db 0x10,0      ; size and reserved
+    dw 0           ; sectors (patched)
+    dd KERNEL_LOAD_ADDR ; load address
+    dq KERNEL_LBA      ; starting LBA
+
+TIMES 510-($-$$) db 0
+DW 0xAA55


### PR DESCRIPTION
## Summary
- implement simple 16-bit bootloader that loads the kernel and enters protected mode
- remove GRUB dependencies from build scripts
- produce a raw image (`OptrixOS.img`) instead of a GRUB ISO
- update README with new instructions

## Testing
- `python3 compile_tools.py`


------
https://chatgpt.com/codex/tasks/task_e_6855eb06ebdc832f93f46bf130fecff5