### PR TITLE
Store OS in virtual hard disk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,9 @@ $(BUILD)/bootloader.bin: $(BUILD)/kernel.bin | $(BUILD)
 	$(NASM) -f bin -DKERNEL_SECTORS=$(SECTORS) src/bootloader.s -o $@
 
 $(IMG): $(BUILD)/bootloader.bin $(BUILD)/kernel.bin
-	cat $(BUILD)/bootloader.bin $(BUILD)/kernel.bin > $@
+	dd if=/dev/zero of=$@ bs=1M count=16
+	dd if=$(BUILD)/bootloader.bin of=$@ conv=notrunc
+	dd if=$(BUILD)/kernel.bin of=$@ bs=512 seek=1 conv=notrunc
 
 $(BUILD)/boot.o: src/boot.s | $(BUILD)
 	$(NASM) -f elf32 $< -o $@

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ This repository contains a very small example OS that now boots using a custom b
 ## Building
 
 1. Install `nasm` and `genisoimage`.
-2. Run `python3 compile_tools.py` or simply `make` to build `OptrixOS.iso`.
-3. Test the ISO with an emulator such as QEMU:
+2. Run `python3 compile_tools.py` or simply `make` to build `OptrixOS.img` and `OptrixOS.iso`.
+3. Boot the OS from the virtual hard drive image with QEMU:
    ```bash
-   qemu-system-i386 -cdrom OptrixOS.iso
+   qemu-system-i386 -hda OptrixOS.img
    ```
 
-The `compile_tools.py` script builds the kernel, creates `OptrixOS.img` and then packages it as a bootable ISO.
+`compile_tools.py` now creates a 16MB hard disk image (`OptrixOS.img`) containing the bootloader and kernel. An ISO is still produced for convenience.

--- a/compile_tools.py
+++ b/compile_tools.py
@@ -54,10 +54,16 @@ def make_image():
     size = os.path.getsize('build/kernel.bin')
     sectors = (size + 511) // 512
     compile_bootloader(sectors)
+
+    disk_size = 16 * 1024 * 1024  # 16MB virtual hard disk
     with open('OptrixOS.img', 'wb') as out:
-        for f in ('build/bootloader.bin', 'build/kernel.bin'):
-            with open(f, 'rb') as inp:
-                out.write(inp.read())
+        out.truncate(disk_size)  # create zero-filled disk image
+        out.seek(0)
+        with open('build/bootloader.bin', 'rb') as inp:
+            out.write(inp.read())
+        out.seek(512)
+        with open('build/kernel.bin', 'rb') as inp:
+            out.write(inp.read())
 
 def make_iso():
     run([MKISOFS_EXE, '-quiet', '-o', 'OptrixOS.iso', '-b', 'OptrixOS.img',

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -5,6 +5,7 @@
 
 static volatile unsigned char *video = (unsigned char *)0xb8000;
 static unsigned short cursor = 0;
+static const unsigned char ATTR = 0x1F; /* white on blue */
 static char current_path[64] = "root";
 
 static inline void outb(uint16_t port, uint8_t val) {
@@ -23,7 +24,7 @@ static void print_char(char c) {
         return;
     }
     video[cursor * 2] = c;
-    video[cursor * 2 + 1] = 0x07;
+    video[cursor * 2 + 1] = ATTR;
     cursor++;
 }
 
@@ -36,8 +37,16 @@ static void backspace(void) {
     if (cursor > 0) {
         cursor--;
         video[cursor * 2] = ' ';
-        video[cursor * 2 + 1] = 0x07;
+        video[cursor * 2 + 1] = ATTR;
     }
+}
+
+static void clear_screen(void) {
+    for (unsigned int i = 0; i < 80 * 25; i++) {
+        video[i * 2] = ' ';
+        video[i * 2 + 1] = ATTR;
+    }
+    cursor = 0;
 }
 
 static const char keymap[128] = {
@@ -115,6 +124,7 @@ static void shell(void) {
 }
 
 void kernel_main(void) {
+    clear_screen();
     print_string("OptrixOS booted\n");
     vfs_init();
     vfs_mount(FS_EXT2);


### PR DESCRIPTION
## Summary
- create a 16MB hard disk image rather than a floppy
- update README to document the new boot method
- set terminal colors to white text on dark blue
- clear screen and print message after kernel boots

## Testing
- `make clean`
- `make` *(fails: `genisoimage` missing)*
- `python3 compile_tools.py` *(fails: `mkisofs` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6855ef5729d4832fa7792e41d9363bd0