### PR TITLE
Fix bootloader load addresses

### DIFF
--- a/src/bootloader.s
+++ b/src/bootloader.s
@@ -37,6 +37,7 @@ start:
     mov sp, 0x7C00
 
     mov [BOOT_DRIVE], dl
+    call enable_a20
 
     ; set up disk address packet
     mov word [dap+2], KERNEL_SECTORS
@@ -60,8 +61,6 @@ start:
     mov ah, 0x42
     int 0x13
     jc disk_error
-
-    call enable_a20
 
     cli
     lgdt [gdt_desc]


### PR DESCRIPTION
## Summary
- enable A20 before loading the kernel so BIOS reads above 1MB work

## Testing
- `make` *(fails: `genisoimage` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855f863acf8832fba2bb13a016e952d