### PR TITLE
Add bootloader debug messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains a very small example OS that now boots using a custom bootloader and prints a message to the screen. It provides a starting point for experimenting with OS development. A basic VFS layer with minimal ext2, FAT32 and NTFS drivers is included for demonstration purposes.
 
+The bootloader now prints simple debug messages during startup so you can observe each stage of the boot process. These messages show when the kernel and root filesystem are loaded and report any disk errors before halting.
+
 ## Building
 
 1. Install `nasm` and `genisoimage`.

--- a/src/bootloader.s
+++ b/src/bootloader.s
@@ -30,6 +30,8 @@
 %endif
 
 start:
+    mov si, msg_start
+    call print_string
     xor ax, ax
     mov ds, ax
     mov es, ax
@@ -38,8 +40,13 @@ start:
 
     mov [BOOT_DRIVE], dl
     call enable_a20
+    mov si, msg_a20
+    call print_string
 
     ; set up disk address packet
+    mov si, msg_load_kernel
+    call print_string
+
     mov word [dap+2], KERNEL_SECTORS
     mov dword [dap+4], KERNEL_LOAD_ADDR
     mov dword [dap+8], KERNEL_LBA
@@ -50,9 +57,13 @@ start:
     mov ah, 0x42
     int 0x13
     jc disk_error
+    mov si, msg_kernel_ok
+    call print_string
 
 %if ROOTFS_SECTORS > 0
     ; load root filesystem if present
+    mov si, msg_load_rootfs
+    call print_string
     mov word [dap+2], ROOTFS_SECTORS
     mov dword [dap+4], ROOTFS_LOAD_ADDR
     mov dword [dap+8], ROOTFS_LBA
@@ -62,13 +73,19 @@ start:
     mov ah, 0x42
     int 0x13
     jc disk_error
+    mov si, msg_rootfs_ok
+    call print_string
 %endif
 
+    mov si, msg_pm
+    call print_string
     cli
     lgdt [gdt_desc]
     mov eax, cr0
     or eax, 1
     mov cr0, eax
+    mov si, msg_jump
+    call print_string
     jmp CODE_SEL:protected
 
 [bits 32]
@@ -87,9 +104,12 @@ protected:
 
 [bits 16]
 disk_error:
+    mov si, msg_disk_error
+    call print_string
     cli
+.halt:
     hlt
-    jmp disk_error
+    jmp .halt
 
 enable_a20:
     in al, 0x92
@@ -121,6 +141,29 @@ gdt_desc:
     dw gdt_end - gdt_start - 1
     dd gdt_start
 
+; BIOS text output utilities
+print_char:
+    mov ah, 0x0E
+    mov bh, 0x00
+    mov bl, 0x07
+    int 0x10
+    ret
+
+print_string:
+    pusha
+.loop:
+    lodsb
+    or al, al
+    jz .done
+    mov ah, 0x0E
+    mov bh, 0x00
+    mov bl, 0x07
+    int 0x10
+    jmp .loop
+.done:
+    popa
+    ret
+
 CODE_SEL equ 0x08
 DATA_SEL equ 0x10
 
@@ -131,6 +174,16 @@ dap:
     dw 0           ; sectors (patched)
     dd 0           ; load address (patched)
     dq 0           ; starting LBA (patched)
+
+msg_start db 'Bootloader start',0
+msg_a20 db 'A20 enabled',0
+msg_load_kernel db 'Loading kernel...',0
+msg_kernel_ok db 'Kernel loaded',0
+msg_load_rootfs db 'Loading rootfs...',0
+msg_rootfs_ok db 'Rootfs loaded',0
+msg_pm db 'Switching to protected mode',0
+msg_jump db 'Jumping to kernel',0
+msg_disk_error db 'Disk read error',0
 
 TIMES 510-($-$$) db 0
 DW 0xAA55


### PR DESCRIPTION
## Summary
- add text output utilities to the bootloader
- print diagnostic messages while loading the kernel and rootfs
- show an error message if disk reads fail
- document debug output in the README

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_6855fc6d6280832faaac7b4093e82792