### PR TITLE
Fix bootloader initialization order

### DIFF
--- a/src/bootloader.s
+++ b/src/bootloader.s
@@ -30,15 +30,15 @@
 %endif
 
 start:
-    mov si, msg_start
-    call print_string
+    cli
     xor ax, ax
     mov ds, ax
     mov es, ax
     mov ss, ax
     mov sp, 0x7C00
-
     mov [BOOT_DRIVE], dl
+    mov si, msg_start
+    call print_string
     call enable_a20
     mov si, msg_a20
     call print_string


### PR DESCRIPTION
## Summary
- set up stack before calling print_string in bootloader

## Testing
- `make` *(fails: `genisoimage` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855fd7fd0d4832f925788a8da7a8d22