### PR TITLE
Improve boot visuals and shell

### DIFF
--- a/OptrixOS/boot/boot.asm
+++ b/OptrixOS/boot/boot.asm
@@ -22,6 +22,8 @@ hang:   jmp hang
 
 ; -- print_string --
 print_string:
+    mov bh, 0x00
+    mov bl, 0x1F
     lodsb
     or al, al
     jz .done

--- a/OptrixOS/boot/stage2.asm
+++ b/OptrixOS/boot/stage2.asm
@@ -30,6 +30,15 @@ start_pm:
     mov ss, ax
     mov esp, 0x90000
 
+    ; clear screen with blue background
+    mov ax, 0x1F20
+    mov edi, 0xb8000
+    mov ecx, 80*25
+.cls_loop:
+    mov [edi], ax
+    add edi, 2
+    loop .cls_loop
+
     mov esi, msg
     call print_string_pm
 
@@ -56,14 +65,14 @@ load_kernel:
 
 ; Print string in protected mode (BIOS video memory write)
 print_string_pm:
-    mov ah, 0x0F
-    mov bh, 0x00
+    mov ebx, 0xb8000
 .next:
     lodsb
     test al, al
     jz .done
-    mov [0xb8000], al
-    add dword [0xb8000], 2
+    mov ah, 0x1F
+    mov [ebx], ax
+    add ebx, 2
     jmp .next
 .done:
     ret

--- a/OptrixOS/src/io.c
+++ b/OptrixOS/src/io.c
@@ -2,6 +2,7 @@
 
 static unsigned short *vidmem = (unsigned short *)0xB8000;
 static unsigned short cursor = 0;
+static unsigned char text_attr = 0x1F; /* white on blue */
 
 void outb(unsigned short port, unsigned char val) {
     asm volatile ("outb %0, %1" : : "a"(val), "Nd"(port));
@@ -11,9 +12,13 @@ unsigned char inb(unsigned short port) {
     asm volatile ("inb %1, %0" : "=a"(ret) : "Nd"(port));
     return ret;
 }
+void set_text_attr(unsigned char attr) {
+    text_attr = attr;
+}
+
 void clear_screen() {
     for (int i = 0; i < 80 * 25; i++)
-        vidmem[i] = 0x0720;
+        vidmem[i] = (text_attr << 8) | 0x20;
     cursor = 0;
 }
 void print(const char* str) {
@@ -21,7 +26,7 @@ void print(const char* str) {
         if (*str == '\n') {
             cursor += 80 - (cursor % 80);
         } else {
-            vidmem[cursor++] = 0x0700 | *str;
+            vidmem[cursor++] = (text_attr << 8) | *str;
         }
         if (cursor >= 80 * 25) cursor = 0;
         str++;

--- a/OptrixOS/src/io.h
+++ b/OptrixOS/src/io.h
@@ -5,5 +5,6 @@ void outb(unsigned short port, unsigned char val);
 unsigned char inb(unsigned short port);
 void clear_screen();
 void print(const char* str);
+void set_text_attr(unsigned char attr);
 
 #endif

--- a/OptrixOS/src/kernel.c
+++ b/OptrixOS/src/kernel.c
@@ -8,6 +8,7 @@ extern void gdt_install();
 void kmain() {
     gdt_install();
     isr_install();
+    set_text_attr(0x1F);
     clear_screen();
     print("DreamOS Kernel Ready\n");
     shell();

--- a/OptrixOS/src/keyboard.c
+++ b/OptrixOS/src/keyboard.c
@@ -1,0 +1,33 @@
+#include "keyboard.h"
+#include "io.h"
+
+static int shift = 0;
+
+static const char sc_ascii[] = {
+    0,27,'1','2','3','4','5','6','7','8','9','0','-','=',8,
+    '\t','q','w','e','r','t','y','u','i','o','p','[',']','\n',0,
+    'a','s','d','f','g','h','j','k','l',';','\'', '`',0,'\\',
+    'z','x','c','v','b','n','m',',','.','/',0,'*',0,' ',0,
+};
+
+static const char sc_ascii_shift[] = {
+    0,27,'!','@','#','$','%','^','&','*','(',')','_','+',8,
+    '\t','Q','W','E','R','T','Y','U','I','O','P','{','}','\n',0,
+    'A','S','D','F','G','H','J','K','L',':','"','~',0,'|',
+    'Z','X','C','V','B','N','M','<','>','?',0,'*',0,' ',0,
+};
+
+char keyboard_getch() {
+    unsigned char c = inb(0x60);
+    if(c & 0x80) {
+        if(c == 0xAA || c == 0xB6)
+            shift = 0;
+        return 0;
+    } else {
+        if(c == 0x2A || c == 0x36) { shift = 1; return 0; }
+        if(c == 0x1C) return '\n';
+        if(c == 0x0E) return 8; // backspace
+        if(c >= sizeof(sc_ascii)) return 0;
+        return shift ? sc_ascii_shift[c] : sc_ascii[c];
+    }
+}

--- a/OptrixOS/src/keyboard.h
+++ b/OptrixOS/src/keyboard.h
@@ -1,0 +1,6 @@
+#ifndef KEYBOARD_H
+#define KEYBOARD_H
+
+char keyboard_getch();
+
+#endif

--- a/OptrixOS/src/shell.c
+++ b/OptrixOS/src/shell.c
@@ -1,29 +1,45 @@
 #include "shell.h"
 #include "io.h"
+#include "keyboard.h"
+#include <stdint.h>
+
+static char cwd[64] = "/";
+
+static void print_prompt() {
+    print("$(");
+    print(cwd);
+    print(")> ");
+}
 
 void shell() {
-    print("DreamOS Shell v1\n> ");
+    print("DreamOS Shell v1\n");
+    print_prompt();
     char input[80];
     int idx = 0;
 
     while (1) {
-        char c = 0;
-        asm volatile ("inb $0x60, %0" : "=a"(c));
-        if (c & 0x80) continue; // key release
-        if (c == 0x1C) { // Enter
+        char c = keyboard_getch();
+        if(!c) continue;
+        if(c == '\n') {
             input[idx] = 0;
             print("\n");
-            if (input[0] == 'h' && input[1] == 'i') print("Hello!\n");
-            else if (input[0] == 'r' && input[1] == 'e' && input[2] == 'b' && input[3] == 'o' && input[4] == 'o' && input[5] == 't')
-                asm volatile ("int $0x19");
-            else print("> ");
+            if(input[0]=='h' && input[1]=='i' && input[2]==0) {
+                print("Hello!\n");
+            } else if(input[0]=='r' && input[1]=='e' && input[2]=='b' && input[3]=='o' && input[4]=='o' && input[5]=='t' && input[6]==0) {
+                asm volatile("int $0x19");
+            } else if(input[0]=='c' && input[1]=='d' && input[2]==' '){
+                int j=3,k=0; while(input[j] && k<63){ cwd[k++]=input[j++]; }
+                cwd[k]=0; if(k==0){ cwd[0]='/'; cwd[1]=0; }
+            } else {
+                print("Unknown command\n");
+            }
             idx = 0;
-        } else if (c == 0x0E && idx > 0) { // Backspace
+            print_prompt();
+        } else if(c == 8 && idx>0) {
             idx--;
-        } else if (c >= 2 && c <= 40 && idx < 79) { // simple ASCII mapping
-            char cc = "1234567890qwertyuiopasdfghjklzxcvbnm"[c-2];
-            input[idx++] = cc;
-            char out[2] = {cc,0};
+        } else if(c >= 32 && idx < 79) {
+            input[idx++] = c;
+            char out[2] = {c,0};
             print(out);
         }
     }

--- a/compile_tools.py
+++ b/compile_tools.py
@@ -48,12 +48,12 @@ def build():
     run([NASM, '-f', 'elf', os.path.join(SRC_DIR, 'gdt.asm'), '-o', os.path.join(BUILD, 'gdt.o')])
     run([NASM, '-f', 'elf', os.path.join(SRC_DIR, 'isr.asm'), '-o', os.path.join(BUILD, 'isr.o')])
 
-    for src in ['kernel.c', 'io.c', 'shell.c', 'idt.c']:
+    for src in ['kernel.c', 'io.c', 'shell.c', 'idt.c', 'keyboard.c']:
         run([CC] + CFLAGS + ['-c', os.path.join(SRC_DIR, src), '-o', os.path.join(BUILD, f"{src[:-2]}.o")])
 
     run([LD, '-m', 'elf_i386', '-Ttext', '0x10000', '-o', os.path.join(BUILD, 'os.elf'),
          os.path.join(BUILD, 'gdt.o'), os.path.join(BUILD, 'io.o'), os.path.join(BUILD, 'kernel.o'),
-         os.path.join(BUILD, 'shell.o'), os.path.join(BUILD, 'idt.o'), os.path.join(BUILD, 'isr.o')])
+         os.path.join(BUILD, 'shell.o'), os.path.join(BUILD, 'keyboard.o'), os.path.join(BUILD, 'idt.o'), os.path.join(BUILD, 'isr.o')])
 
     run([OBJCOPY, '-O', 'binary', os.path.join(BUILD, 'os.elf'), os.path.join(BUILD, 'os.bin')])
 


### PR DESCRIPTION
## Summary
- display boot text in blue screen theme
- clear screen in stage2 with blue background
- allow setting text color at runtime
- add basic keyboard driver
- enhance shell with $(path)> prompt
- compile keyboard source when building OS

## Testing
- `python3 compile_tools.py`

------
https://chatgpt.com/codex/tasks/task_e_68564e561ea0832fa1dd989bc29d44e8