### PR TITLE
Add minimal NASM bootloader and kernel

### DIFF
--- a/OptrixOS/asm/kernel.asm
+++ b/OptrixOS/asm/kernel.asm
@@ -1,0 +1,50 @@
+[BITS 16]
+[ORG 0x1000]
+
+kernel_start:
+    cli
+    xor ax, ax
+    mov ds, ax
+    mov es, ax
+
+    mov ax, 0xB800
+    mov es, ax
+
+    mov di, 0
+    mov cx, 80*25
+    mov ax, 0x1F20        ; white on blue space
+.fill:
+    mov [es:di], ax
+    add di, 2
+    loop .fill
+
+    ; reset cursor to 0,0
+    mov dx, 0x3D4
+    mov al, 0x0F
+    out dx, al
+    inc dx
+    xor al, al
+    out dx, al
+    mov dx, 0x3D4
+    mov al, 0x0E
+    out dx, al
+    inc dx
+    xor al, al
+    out dx, al
+
+    mov si, message
+    mov di, 0
+.print:
+    lodsb
+    or al, al
+    jz .halt
+    mov ah, 0x1F
+    mov [es:di], ax
+    add di, 2
+    jmp .print
+
+.halt:
+    hlt
+    jmp .halt
+
+message db 'Welcome to OptrixOS',0

--- a/OptrixOS/boot/boot.asm
+++ b/OptrixOS/boot/boot.asm
@@ -1,0 +1,47 @@
+[BITS 16]
+[ORG 0x7C00]
+
+boot_start:
+    cli
+    xor ax, ax
+    mov ds, ax
+    mov es, ax
+    mov ss, ax
+    mov sp, 0x7C00
+
+    mov [boot_drive], dl
+
+    ; Read stage2 from disk
+    mov bx, 0x7E00          ; load address
+    mov dh, 0               ; head
+    mov dl, [boot_drive]
+    mov ah, 0x02            ; read sectors
+    mov al, STAGE2_SECTORS
+    mov ch, 0
+    mov cl, 2               ; starting sector 2
+    int 0x13
+    jc disk_error
+
+    jmp 0x0000:0x7E00
+
+disk_error:
+    mov si, err_msg
+    call print
+    jmp $
+
+print:
+    mov ah, 0x0E
+.next:
+    lodsb
+    test al, al
+    jz .done
+    int 0x10
+    jmp .next
+.done:
+    ret
+
+boot_drive db 0
+err_msg db 'Boot error',0
+
+times 510-($-$$) db 0
+DW 0xAA55

--- a/OptrixOS/boot/stage2.asm
+++ b/OptrixOS/boot/stage2.asm
@@ -1,0 +1,54 @@
+[BITS 16]
+[ORG 0x7E00]
+
+%ifndef KERNEL_LOAD_ADDR
+%define KERNEL_LOAD_ADDR 0x1000
+%endif
+%ifndef KERNEL_START_SECTOR
+%define KERNEL_START_SECTOR 2
+%endif
+%ifndef KERNEL_SECTORS
+%define KERNEL_SECTORS 1
+%endif
+
+stage2_start:
+    cli
+    xor ax, ax
+    mov ds, ax
+    mov es, ax
+    mov ss, ax
+    mov sp, 0x7E00
+
+    mov [boot_drive], dl
+
+    ; load kernel
+    mov bx, KERNEL_LOAD_ADDR
+    mov dh, 0
+    mov dl, [boot_drive]
+    mov ah, 0x02
+    mov al, KERNEL_SECTORS
+    mov ch, 0
+    mov cl, KERNEL_START_SECTOR
+    int 0x13
+    jc disk_error
+
+    jmp 0x0000:KERNEL_LOAD_ADDR
+
+disk_error:
+    mov si, err_msg
+    call print
+    jmp $
+
+print:
+    mov ah, 0x0E
+.next:
+    lodsb
+    test al, al
+    jz .done
+    int 0x10
+    jmp .next
+.done:
+    ret
+
+boot_drive db 0
+err_msg db 'Stage2 error',0

--- a/README.md
+++ b/README.md
@@ -1,21 +1,19 @@
 # OptrixOS-Codex
 
-This repository contains a very small example OS that now boots using a custom bootloader and prints a message to the screen. It provides a starting point for experimenting with OS development. A basic VFS layer with minimal ext2, FAT32 and NTFS drivers is included for demonstration purposes.
+This repository demonstrates a very small example operating system.  The bootloader loads a tiny kernel that clears the screen to a blue background with white text and displays a short message.
 
-The bootloader now prints simple debug messages during startup so you can observe each stage of the boot process. These messages show when the kernel and root filesystem are loaded and report any disk errors before halting.
+## Directory layout
+
+- `OptrixOS/boot` – first and second stage bootloaders (`boot.asm`, `stage2.asm`)
+- `OptrixOS/asm` – assembly sources for the kernel (`kernel.asm`)
+- `OptrixOS/c` – C sources (empty by default)
+- `OptrixOS/h` – header files (empty by default)
 
 ## Building
 
-1. Install `nasm` and `genisoimage`.
-2. Run `python3 compile_tools.py` or simply `make` to build `OptrixOS.iso`.
+1. Install `nasm` and `mkisofs` (sometimes provided by the `genisoimage` package).
+2. Run `python3 compile_tools.py` to produce `OptrixOS.iso`.
 3. Boot the ISO with QEMU:
    ```bash
    qemu-system-i386 -cdrom OptrixOS.iso
    ```
-
-`compile_tools.py` now builds a 16MB disk image with two partitions.  The first
-bootable partition contains the bootloader and kernel while the second is an
-ext2 formatted partition holding a tiny root filesystem.  After booting the
-kernel launches a simple command shell.
-
-The intermediate image is removed after the ISO is created.

--- a/compile_tools.py
+++ b/compile_tools.py
@@ -1,102 +1,93 @@
 import os
 import shutil
 import subprocess
-import glob
+import math
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = os.path.join(SCRIPT_DIR, 'OptrixOS')
+BOOT_DIR = os.path.join(ROOT_DIR, 'boot')
+ASM_DIR = os.path.join(ROOT_DIR, 'asm')
+C_DIR = os.path.join(ROOT_DIR, 'c')
+H_DIR = os.path.join(ROOT_DIR, 'h')
 BUILD = os.path.join(SCRIPT_DIR, 'build')
-BOOT_DIR = os.path.join(SCRIPT_DIR, 'OptrixOS', 'boot')
-SRC_DIR = os.path.join(SCRIPT_DIR, 'OptrixOS', 'src')
 ISO_NAME = os.path.join(SCRIPT_DIR, 'OptrixOS.iso')
 
-# Toolchain config
-TOOLCHAIN_DIR = os.environ.get("TOOLCHAIN_DIR") or r"C:\Users\jaide\Downloads\i686-elf-tools-windows\bin"
-CC = os.environ.get("CC") or os.path.join(TOOLCHAIN_DIR, "i686-elf-gcc.exe")
-LD = os.environ.get("LD") or os.path.join(TOOLCHAIN_DIR, "i686-elf-ld.exe")
-OBJCOPY = os.environ.get("OBJCOPY") or os.path.join(TOOLCHAIN_DIR, "i686-elf-objcopy.exe")
-NASM = "nasm"
-
-if not os.path.isfile(CC): CC = shutil.which("i686-linux-gnu-gcc") or "i686-linux-gnu-gcc"
-if not os.path.isfile(LD): LD = shutil.which("i686-linux-gnu-ld") or "i686-linux-gnu-ld"
-if not os.path.isfile(OBJCOPY): OBJCOPY = shutil.which("i686-linux-gnu-objcopy") or "i686-linux-gnu-objcopy"
-if not shutil.which(CC): CC = "gcc"
-if not shutil.which(LD): LD = "ld"
-if not shutil.which(OBJCOPY): OBJCOPY = "objcopy"
-
-CDRTOOLS_DIR = os.environ.get("CDRTOOLS_DIR") or r"C:\Program Files (x86)\cdrtools"
-MKISOFS_EXE = os.environ.get("MKISOFS") or os.path.join(CDRTOOLS_DIR, "mkisofs.exe")
-if not os.path.isfile(MKISOFS_EXE): MKISOFS_EXE = shutil.which("mkisofs") or "mkisofs"
-
-CFLAGS = [
-    '-m32', '-ffreestanding', '-fno-pic', '-nostdlib', '-fno-stack-protector'
-]
+NASM = shutil.which('nasm') or 'nasm'
+MKISOFS = shutil.which('mkisofs') or 'mkisofs'
 
 def run(cmd):
-    print(' '.join([str(x) for x in cmd]))
+    print(' '.join(str(x) for x in cmd))
     subprocess.check_call(cmd)
 
+
 def copytree_overwrite(src, dst):
-    # Python 3.8+ has dirs_exist_ok, but let's be universal
     if os.path.exists(dst):
         shutil.rmtree(dst)
     shutil.copytree(src, dst)
 
-def build():
+
+def assemble():
     os.makedirs(BUILD, exist_ok=True)
-    run([NASM, '-f', 'bin', os.path.join(BOOT_DIR, 'boot.asm'), '-o', os.path.join(BUILD, 'boot.bin')])
-    run([NASM, '-f', 'bin', os.path.join(BOOT_DIR, 'stage2.asm'), '-o', os.path.join(BUILD, 'stage2.bin')])
-    run([NASM, '-f', 'elf', os.path.join(SRC_DIR, 'gdt.asm'), '-o', os.path.join(BUILD, 'gdt.o')])
-    run([NASM, '-f', 'elf', os.path.join(SRC_DIR, 'isr.asm'), '-o', os.path.join(BUILD, 'isr.o')])
+    stage2_bin = os.path.join(BUILD, 'stage2.bin')
+    run([NASM, '-f', 'bin', os.path.join(BOOT_DIR, 'stage2.asm'), '-o', stage2_bin])
+    stage2_sectors = math.ceil(os.path.getsize(stage2_bin) / 512)
 
-    for src in ['kernel.c', 'io.c', 'shell.c', 'idt.c', 'keyboard.c']:
-        run([CC] + CFLAGS + ['-c', os.path.join(SRC_DIR, src), '-o', os.path.join(BUILD, f"{src[:-2]}.o")])
+    kernel_bin = os.path.join(BUILD, 'kernel.bin')
+    run([NASM, '-f', 'bin', os.path.join(ASM_DIR, 'kernel.asm'), '-o', kernel_bin])
+    kernel_sectors = math.ceil(os.path.getsize(kernel_bin) / 512)
 
-    run([LD, '-m', 'elf_i386', '-Ttext', '0x10000', '-o', os.path.join(BUILD, 'os.elf'),
-         os.path.join(BUILD, 'gdt.o'), os.path.join(BUILD, 'io.o'), os.path.join(BUILD, 'kernel.o'),
-         os.path.join(BUILD, 'shell.o'), os.path.join(BUILD, 'keyboard.o'), os.path.join(BUILD, 'idt.o'), os.path.join(BUILD, 'isr.o')])
+    run([NASM, '-f', 'bin',
+         f'-DKERNEL_START_SECTOR={1 + stage2_sectors}',
+         f'-DKERNEL_SECTORS={kernel_sectors}',
+         os.path.join(BOOT_DIR, 'stage2.asm'), '-o', stage2_bin])
 
-    run([OBJCOPY, '-O', 'binary', os.path.join(BUILD, 'os.elf'), os.path.join(BUILD, 'os.bin')])
+    boot_bin = os.path.join(BUILD, 'boot.bin')
+    run([NASM, '-f', 'bin', f'-DSTAGE2_SECTORS={stage2_sectors}',
+         os.path.join(BOOT_DIR, 'boot.asm'), '-o', boot_bin])
+    return stage2_sectors
 
-    # --- Create raw boot image (floppy) ---
+
+def create_image(stage2_sectors):
+    boot_bin = os.path.join(BUILD, 'boot.bin')
+    stage2_bin = os.path.join(BUILD, 'stage2.bin')
+    kernel_bin = os.path.join(BUILD, 'kernel.bin')
+
     img_path = os.path.join(BUILD, 'boot.img')
     run(['dd', 'if=/dev/zero', f'of={img_path}', 'bs=512', 'count=2880'])
-    run(['dd', f'if={os.path.join(BUILD, "boot.bin")}', f'of={img_path}', 'conv=notrunc'])
-    run(['dd', f'if={os.path.join(BUILD, "stage2.bin")}', f'of={img_path}', 'seek=1', 'conv=notrunc'])
-    run(['dd', f'if={os.path.join(BUILD, "os.bin")}', f'of={img_path}', 'seek=4', 'conv=notrunc'])
+    run(['dd', f'if={boot_bin}', f'of={img_path}', 'conv=notrunc'])
+    run(['dd', f'if={stage2_bin}', f'of={img_path}', 'seek=1', 'conv=notrunc'])
+    run(['dd', f'if={kernel_bin}', f'of={img_path}', f'seek={1 + stage2_sectors}', 'conv=notrunc'])
+    return img_path
 
-    # --- Prepare ISO staging area ---
+
+def create_iso(img_path):
     iso_root = os.path.join(BUILD, 'iso_root')
     os.makedirs(iso_root, exist_ok=True)
-
-    # Place boot image at root for El Torito boot
     shutil.copy(img_path, os.path.join(iso_root, 'boot.img'))
+    copytree_overwrite(ROOT_DIR, os.path.join(iso_root, 'OptrixOS'))
+    run([MKISOFS, '-quiet', '-V', 'OPTRIXOS', '-input-charset', 'iso8859-1', '-o', ISO_NAME,
+         '-b', 'boot.img', '-no-emul-boot', '-boot-load-size', '4', '-boot-info-table', iso_root])
 
-    # Copy OptrixOS/boot and OptrixOS/src as directories (with all files/subdirs)
-    BOOT_DST = os.path.join(iso_root, 'boot')
-    SRC_DST = os.path.join(iso_root, 'src')
-    copytree_overwrite(BOOT_DIR, BOOT_DST)
-    copytree_overwrite(SRC_DIR, SRC_DST)
 
-    # Optionally: copy the built kernel, or any additional files you want accessible in the ISO root
-    shutil.copy(os.path.join(BUILD, 'os.bin'), os.path.join(iso_root, 'os.bin'))
-    shutil.copy(os.path.join(BUILD, 'os.elf'), os.path.join(iso_root, 'os.elf'))
+def cleanup():
+    if not os.path.isdir(BUILD):
+        return
+    for f in os.listdir(BUILD):
+        path = os.path.join(BUILD, f)
+        if os.path.isdir(path):
+            shutil.rmtree(path, ignore_errors=True)
+        else:
+            os.remove(path)
+    shutil.rmtree(BUILD, ignore_errors=True)
 
-    # --- Create ISO with boot and all source folders included ---
-    run([
-        MKISOFS_EXE, '-quiet', '-V', 'OPTRIXOS', '-input-charset', 'iso8859-1', '-o', ISO_NAME,
-        '-b', 'boot.img', '-no-emul-boot', '-boot-load-size', '4', '-boot-info-table', iso_root
-    ])
 
+def build():
+    stage2_sectors = assemble()
+    img = create_image(stage2_sectors)
+    create_iso(img)
+    cleanup()
     print('ISO created at', ISO_NAME)
 
-    # --- Cleanup everything except the ISO ---
-    for f in glob.glob(os.path.join(BUILD, '*')):
-        if os.path.isdir(f):
-            shutil.rmtree(f, ignore_errors=True)
-        else:
-            os.remove(f)
-    shutil.rmtree(BUILD, ignore_errors=True)
-    print('All build/temp files deleted, ISO remains:', ISO_NAME)
 
 if __name__ == '__main__':
     build()


### PR DESCRIPTION
## Summary
- add boot and kernel assembly sources under `OptrixOS/`
- simplify build system in `compile_tools.py`
- update README for new build instructions

## Testing
- `python3 compile_tools.py`

------
https://chatgpt.com/codex/tasks/task_e_685651d2517c832f9fdc0b6fdad2a8d2