### PR TITLE
Implement simple shell with drivers

### DIFF
--- a/OptrixOS/asm/kernel.asm
+++ b/OptrixOS/asm/kernel.asm
@@ -1,50 +1,18 @@
 [BITS 16]
 [ORG 0x1000]
 
+%include "shell.asm"
+
 kernel_start:
     cli
     xor ax, ax
     mov ds, ax
     mov es, ax
+    mov ss, ax
+    mov sp, 0x7C00
 
-    mov ax, 0xB800
-    mov es, ax
-
-    mov di, 0
-    mov cx, 80*25
-    mov ax, 0x1F20        ; white on blue space
-.fill:
-    mov [es:di], ax
-    add di, 2
-    loop .fill
-
-    ; reset cursor to 0,0
-    mov dx, 0x3D4
-    mov al, 0x0F
-    out dx, al
-    inc dx
-    xor al, al
-    out dx, al
-    mov dx, 0x3D4
-    mov al, 0x0E
-    out dx, al
-    inc dx
-    xor al, al
-    out dx, al
-
-    mov si, message
-    mov di, 0
-.print:
-    lodsb
-    or al, al
-    jz .halt
-    mov ah, 0x1F
-    mov [es:di], ax
-    add di, 2
-    jmp .print
+    call shell_start
 
 .halt:
     hlt
     jmp .halt
-
-message db 'Welcome to OptrixOS',0

--- a/OptrixOS/asm/shell.asm
+++ b/OptrixOS/asm/shell.asm
@@ -1,0 +1,147 @@
+[BITS 16]
+
+%include "../drivers/keyboard.asm"
+%include "../drivers/video.asm"
+
+path_current db 'root/',0
+prompt_suffix db '> ',0
+welcome_msg db 'Welcome to OptrixOS Shell',0
+help_msg db 'Available commands: help, clear, echo',0
+unknown_msg db 'Unknown command',0
+
+str_help db 'help',0
+str_clear db 'clear',0
+str_echo db 'echo ',0
+
+input_buf times 128 db 0
+
+; Read a line into input_buf, result in input_buf
+input_line:
+    mov di, input_buf
+    xor cx, cx
+.read:
+    call kbd_getch
+    cmp al, 13
+    je .done
+    cmp al, 8
+    je .backspace
+    call vid_putc
+    stosb
+    inc cx
+    cmp cx, 126
+    jb .read
+    jmp .read
+.backspace:
+    cmp cx, 0
+    je .read
+    dec di
+    dec cx
+    mov al, 8
+    call vid_putc
+    mov al, ' '
+    call vid_putc
+    mov al, 8
+    call vid_putc
+    jmp .read
+.done:
+    call vid_newline
+    mov al, 0
+    stosb
+    ret
+
+; Compare strings DS:SI and DS:DI, set AL=0 if equal
+strcmp:
+    push si
+    push di
+.loop:
+    lodsb
+    mov bl, [di]
+    inc di
+    cmp al, bl
+    jne .noteq
+    or al, al
+    jne .loop
+    mov al, 0
+    jmp .finish
+.noteq:
+    mov al, 1
+.finish:
+    pop di
+    pop si
+    ret
+
+; Check if input starts with 'echo '
+check_echo:
+    push si
+    push di
+    mov si, input_buf
+    mov di, str_echo
+    mov cx, 5
+.loop_e:
+    lodsb
+    mov bl, [di]
+    inc di
+    cmp al, bl
+    jne .noteq_e
+    loop .loop_e
+    mov al, 0
+    jmp .end_e
+.noteq_e:
+    mov al, 1
+.end_e:
+    pop di
+    pop si
+    ret
+
+shell_start:
+    call vid_clear
+    mov si, welcome_msg
+    call vid_print
+    call vid_newline
+
+.shell_loop:
+    mov al, '$'
+    call vid_putc
+    mov si, path_current
+    call vid_print
+    mov si, prompt_suffix
+    call vid_print
+
+    call input_line
+
+    mov si, input_buf
+    mov di, str_help
+    call strcmp
+    cmp al, 0
+    je .do_help
+
+    mov si, input_buf
+    mov di, str_clear
+    call strcmp
+    cmp al, 0
+    je .do_clear
+
+    call check_echo
+    cmp al, 0
+    je .do_echo
+
+    mov si, unknown_msg
+    call vid_print
+    call vid_newline
+    jmp .shell_loop
+
+.do_help:
+    mov si, help_msg
+    call vid_print
+    call vid_newline
+    jmp .shell_loop
+
+.do_clear:
+    call vid_clear
+    jmp .shell_loop
+
+.do_echo:
+    mov si, input_buf + 5
+    call vid_print
+    call vid_newline
+    jmp .shell_loop

--- a/OptrixOS/drivers/keyboard.asm
+++ b/OptrixOS/drivers/keyboard.asm
@@ -1,0 +1,7 @@
+[BITS 16]
+
+; Wait for a key press and return ASCII in AL
+kbd_getch:
+    mov ah, 0x00
+    int 0x16
+    ret

--- a/OptrixOS/drivers/video.asm
+++ b/OptrixOS/drivers/video.asm
@@ -1,0 +1,46 @@
+[BITS 16]
+
+; Print character in AL at current cursor position using BIOS
+vid_putc:
+    mov ah, 0x0E
+    mov bh, 0x00
+    mov bl, 0x07
+    int 0x10
+    ret
+
+; Print null-terminated string at DS:SI
+vid_print:
+    push ax
+.print_loop:
+    lodsb
+    or al, al
+    jz .done
+    call vid_putc
+    jmp .print_loop
+.done:
+    pop ax
+    ret
+
+; Output CRLF
+vid_newline:
+    push ax
+    mov al, 0x0D
+    call vid_putc
+    mov al, 0x0A
+    call vid_putc
+    pop ax
+    ret
+
+; Clear screen and reset cursor
+vid_clear:
+    mov ax, 0x0600
+    mov bh, 0x07
+    mov cx, 0
+    mov dx, 0x184F
+    int 0x10
+    mov ah, 0x02
+    mov bh, 0
+    mov dh, 0
+    mov dl, 0
+    int 0x10
+    ret

--- a/compile_tools.py
+++ b/compile_tools.py
@@ -48,16 +48,40 @@ def assemble():
     kernel_bin = os.path.join(BUILD, 'kernel.bin')
     boot_bin = os.path.join(BUILD, 'boot.bin')
 
-    run([NASM, '-f', 'bin', os.path.join(BOOT_DIR, 'stage2.asm'), '-o', stage2_bin])
+    run([NASM, '-f', 'bin', '-I', BOOT_DIR + '/', os.path.join(BOOT_DIR, 'stage2.asm'), '-o', stage2_bin])
     stage2_sectors = math.ceil(os.path.getsize(stage2_bin) / 512)
-    run([NASM, '-f', 'bin', os.path.join(ASM_DIR, 'kernel.asm'), '-o', kernel_bin])
+    run([
+        NASM,
+        '-f',
+        'bin',
+        '-I', ASM_DIR + '/',
+        '-I', os.path.join(ROOT_DIR, 'drivers') + '/',
+        os.path.join(ASM_DIR, 'kernel.asm'),
+        '-o',
+        kernel_bin,
+    ])
     kernel_sectors = math.ceil(os.path.getsize(kernel_bin) / 512)
-    run([NASM, '-f', 'bin',
-         f'-DKERNEL_START_SECTOR={2 + stage2_sectors}',
-         f'-DKERNEL_SECTORS={kernel_sectors}',
-         os.path.join(BOOT_DIR, 'stage2.asm'), '-o', stage2_bin])
-    run([NASM, '-f', 'bin', f'-DSTAGE2_SECTORS={stage2_sectors}',
-         os.path.join(BOOT_DIR, 'boot.asm'), '-o', boot_bin])
+    run([
+        NASM,
+        '-f',
+        'bin',
+        '-I', BOOT_DIR + '/',
+        f'-DKERNEL_START_SECTOR={2 + stage2_sectors}',
+        f'-DKERNEL_SECTORS={kernel_sectors}',
+        os.path.join(BOOT_DIR, 'stage2.asm'),
+        '-o',
+        stage2_bin,
+    ])
+    run([
+        NASM,
+        '-f',
+        'bin',
+        '-I', BOOT_DIR + '/',
+        f'-DSTAGE2_SECTORS={stage2_sectors}',
+        os.path.join(BOOT_DIR, 'boot.asm'),
+        '-o',
+        boot_bin,
+    ])
 
     # Only build C sources if the directory exists
     if os.path.isdir(C_DIR):


### PR DESCRIPTION
## Summary
- add keyboard and video driver code using BIOS services
- implement a tiny interactive shell that supports `help`, `clear` and `echo`
- include shell handler from kernel start
- update build script to pass include paths for NASM

## Testing
- `python3 compile_tools.py` *(fails: FileNotFoundError: 'mkisofs')*

------
https://chatgpt.com/codex/tasks/task_e_685657b16e3c832fa1bf10b50468a468