### PR TITLE
Add boot debug messages

### DIFF
--- a/OptrixOS/asm/kernel.asm
+++ b/OptrixOS/asm/kernel.asm
@@ -33,9 +33,9 @@ kernel_start:
     out dx, al
 
 
-    ; print welcome message on first line
+    ; print kernel message on first line
     mov di, 0
-    mov si, message
+    mov si, kernel_msg
     call print_string
 
     ; print BIOS information on second line
@@ -115,7 +115,7 @@ print_hex16:
     pop ax
     ret
 
-message db 'Welcome to OptrixOS',0
+kernel_msg db 'OptrixOS Kernel Loaded',0
 bios_label db 'BIOS Drive: 0x',0
 mem_label db ' Memory: 0x',0
 kb_suffix db ' KB',0

--- a/OptrixOS/boot/boot.asm
+++ b/OptrixOS/boot/boot.asm
@@ -9,6 +9,9 @@ boot_start:
     mov ss, ax
     mov sp, 0x7C00
 
+    mov si, msg_stage1
+    call print
+
     mov [boot_drive], dl
 
     ; Read stage2 from disk
@@ -21,6 +24,9 @@ boot_start:
     mov cl, 2               ; starting sector 2
     int 0x13
     jc disk_error
+
+    mov si, msg_stage1_ok
+    call print
 
     jmp 0x0000:0x7E00
 
@@ -42,6 +48,8 @@ print:
 
 boot_drive db 0
 err_msg db 'Boot error',0
+msg_stage1 db 'Stage1: Loading Stage2...',0
+msg_stage1_ok db 'Stage1 OK',0
 
 times 510-($-$$) db 0
 DW 0xAA55

--- a/OptrixOS/boot/stage2.asm
+++ b/OptrixOS/boot/stage2.asm
@@ -19,9 +19,14 @@ stage2_start:
     mov ss, ax
     mov sp, 0x7E00
 
+    mov si, msg_stage2
+    call print
+
     mov [boot_drive], dl
 
     ; load kernel
+    mov si, msg_kernel
+    call print
     mov bx, KERNEL_LOAD_ADDR
     mov dh, 0
     mov dl, [boot_drive]
@@ -31,6 +36,9 @@ stage2_start:
     mov cl, KERNEL_START_SECTOR
     int 0x13
     jc disk_error
+
+    mov si, msg_kernel_ok
+    call print
 
     mov dl, [boot_drive]
     jmp 0x0000:KERNEL_LOAD_ADDR
@@ -53,3 +61,6 @@ print:
 
 boot_drive db 0
 err_msg db 'Stage2 error',0
+msg_stage2 db 'Stage2: Start...',0
+msg_kernel db 'Loading kernel...',0
+msg_kernel_ok db 'Kernel loaded',0


### PR DESCRIPTION
## Summary
- add startup/OK messages to the bootloader
- print stage2 and kernel load messages
- show kernel boot message on screen

## Testing
- `python3 compile_tools.py`


------
https://chatgpt.com/codex/tasks/task_e_6856cdbc606c832f8d8bc9fcd679c4f8